### PR TITLE
Change label in player vs player game

### DIFF
--- a/iOS-tic-tac-toe/PlayerVsPlayer.swift
+++ b/iOS-tic-tac-toe/PlayerVsPlayer.swift
@@ -17,6 +17,10 @@ public class PlayerVsPlayer : Game {
     }
 
     public func getTurnMessage() -> String {
-        return UIConfig.getLabelForPlayerVsPlayerGame(isXTurn)
+        if (isXTurn) {
+            return "\(UIConfig.player1)'s Turn!!"
+        } else {
+            return "\(UIConfig.player2)'s Turn!!"
+        }
     }
 }

--- a/iOS-tic-tac-toeTests/GameInteractorTests.swift
+++ b/iOS-tic-tac-toeTests/GameInteractorTests.swift
@@ -64,7 +64,7 @@ class GameInteractorTests: QuickSpec {
                 gameInteractor.game.status = Status.inProgress
                 gameInteractor.completeTurn()
                 
-                expect(mockStatusView.statusMessage).to(equal("Player 2's Turn!"))
+                expect(mockStatusView.statusMessage).to(contain("'s Turn!"))
             }
             
             it("changes the label at the end of the game if O wins") {
@@ -86,7 +86,7 @@ class GameInteractorTests: QuickSpec {
                 gameInteractor.game.isXTurn = true
                 
                 gameInteractor.nextTurn()
-                expect(mockStatusView.statusMessage).to(contain("Player 2"))
+                expect(mockStatusView.statusMessage).to(contain(UIConfig.player2))
             }
             
             it("can create JSON for us") {

--- a/iOS-tic-tac-toeTests/GameTests.swift
+++ b/iOS-tic-tac-toeTests/GameTests.swift
@@ -47,15 +47,16 @@ class GameTests: QuickSpec {
             it("returns text that includes the Player 1's name") {
                 game.isXTurn = true
                 let nextPlayerText = game.getTurnMessage()
-                expect(nextPlayerText).to(contain("Player 1"))
+                expect(nextPlayerText).to(contain(UIConfig.player1))
             }
 
             it("returns text that includes the Player 2's name") {
                 game.isXTurn = false
                 let nextPlayerText = game.getTurnMessage()
-                expect(nextPlayerText).to(contain("Player 2"))
+                expect(nextPlayerText).to(contain(UIConfig.player2))
             }
 
+            
             it("returns 'Your turn!' if it is the human player's turn") {
                 game = PlayerVsComputer()
                 let nextPlayerText = game.getTurnMessage()

--- a/iOS-tic-tac-toeTests/StatusLabelViewTests.swift
+++ b/iOS-tic-tac-toeTests/StatusLabelViewTests.swift
@@ -10,7 +10,7 @@ class StatusLabelViewSpec: QuickSpec {
                 let game = PlayerVsPlayer()
                 playerLabel.text = ""
                 playerLabel.displayTurn(message: game.getTurnMessage())
-                expect(playerLabel.text).to(contain("Player 1"))
+                expect(playerLabel.text).to(contain(UIConfig.player1))
             }
             
             it ("can set the status label when there's a tie") {


### PR DESCRIPTION
Previously the label would say Player 1's Turn or Player 2's Turn in a player vs player game.
The new behavior displays the player's marker instead to reduce confusion of who is 'player 1' or 'player 2'.
